### PR TITLE
#28 stream cn.jpush.android.EXTRA from JSONObject to String

### DIFF
--- a/src/android/JPushPlugin.java
+++ b/src/android/JPushPlugin.java
@@ -78,7 +78,12 @@ public class JPushPlugin extends CordovaPlugin {
 			data.put("message", message);
 			JSONObject jExtras = new JSONObject();
 			for(Entry<String,Object> entry:extras.entrySet()){
-				jExtras.put(entry.getKey(),entry.getValue());
+				if(entry.getKey().equals("cn.jpush.android.EXTRA")){
+					JSONObject jo = new JSONObject((String)entry.getValue());
+                    jExtras.put("cn.jpush.android.EXTRA", jo);
+                } else {
+                    jExtras.put(entry.getKey(),entry.getValue());
+                }
 			}
 			if(jExtras.length()>0)
 			{


### PR DESCRIPTION
与 #21 解一样的问题，否则在 javascript 里得到的 data 用 JSON.parse 会报错误

![image](https://cloud.githubusercontent.com/assets/3538629/6199027/dd904148-b463-11e4-9560-9ac5f98bcd3c.png)


原因是未将cn.jpush.android.EXTRA正确的转换成 String