### PR TITLE
抽离API_KEY的配置

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -10,12 +10,14 @@
     <keywords>JPush,push</keywords>
     <license>Apache 2.0 License</license>
 
+    <preference name="API_KEY" />
+
     <engines>
         <engine name="cordova" version=">=3.0"/>
     </engines>
 
     <js-module src="www/JPushPlugin.js" name="JPushPlugin">
-            <clobbers target="window.plugins.jPushPlugin"/>
+            <clobbers target="jPushPlugin"/>
     </js-module>
 
     <platform name="ios">
@@ -42,11 +44,18 @@
             <framework src="UIKit.framework" weak="true" />
             <framework src="Security.framework" weak="true" />
             <framework src="libz.dylib" weak="true" />
-            
+
+            <config-file target="*PushConfig.plist" parent="APP_KEY">
+                <string>$API_KEY</string>
+            </config-file>
         </platform>
         
     <!-- android -->
     <platform name="android">
+        <hook type="after_plugin_add" src="scripts/android-install.js" />
+        <hook type="after_plugin_install" src="scripts/android-install.js" />
+        <hook type="before_plugin_rm" src="scripts/android-install.js" />
+        <hook type="before_plugin_uninstall" src="scripts/android-install.js" />
     
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="JPushPlugin">
@@ -152,14 +161,14 @@
             <receiver android:name="cn.jpush.android.service.AlarmReceiver"/>
             <!-- Required  . Enable it you can get statistics data with channel -->
             <meta-data android:name="JPUSH_CHANNEL" android:value="developer-default"/>
-            <meta-data android:name="JPUSH_APPKEY" android:value="your appkey"/>
+            <meta-data android:name="JPUSH_APPKEY" android:value="$API_KEY"/>
         </config-file>
         <source-file src="src/android/jpush-sdk-release1.7.5.jar" target-dir="libs"/>
         <source-file src="src/android/armeabi/libjpush175.so" target-dir="libs/armeabi"/>
         <source-file src="src/android/armeabi-v7a/libjpush175.so" target-dir="libs/armeabi-v7a"/>
         <source-file src="src/android/arm64-v8a/libjpush175.so" target-dir="libs/arm64-v8a"/>
         
-        <source-file src="src/android/JPushPlugin.java" target-dir="src/cn/jpush/phonegap"/>
+        <!--<source-file src="src/android/JPushPlugin.java" target-dir="src/cn/jpush/phonegap"/>-->
         <source-file src="src/android/MyReceiver.java" target-dir="src/cn/jpush/phonegap"/>
     	<source-file src="src/android/test_notification_layout.xml" target-dir="res/layout"/>
     	<source-file src="src/android/jpush_notification_icon.png" target-dir="res/drawable"/>

--- a/scripts/android-install.js
+++ b/scripts/android-install.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+module.exports = function (context) {
+    var path         = context.requireCordovaModule('path'),
+        fs           = context.requireCordovaModule('fs'),
+        shell        = context.requireCordovaModule('shelljs'),
+        projectRoot  = context.opts.projectRoot,
+        ConfigParser = context.requireCordovaModule('cordova-lib/src/configparser/ConfigParser'),
+        config       = new ConfigParser(path.join(context.opts.projectRoot, "config.xml")),
+        packageName = config.android_packageName() || config.packageName();
+
+    console.info("Running android-install.Hook: " + context.hook + ", Package: " + packageName + ", Path: " + projectRoot + ".");
+
+    if (!packageName) {
+        console.error("Package name could not be found!");
+        return ;
+    }
+
+    // android platform available?
+    if (context.opts.cordova.platforms.indexOf("android") === -1) {
+        console.info("Android platform has not been added.");
+        return ;
+    }
+
+    var targetDir  = path.join(projectRoot, "platforms", "android", "src", "cn", "jpush", "phonegap");
+        targetFile = path.join(targetDir, "JPushPlugin.java");
+        console.log(targetDir);
+
+    if (['after_plugin_add', 'after_plugin_install', 'after_platform_add'].indexOf(context.hook) === -1) {
+        // remove it?
+        try {
+            fs.unlinkSync(targetFile);
+        } catch (err) {}
+    } else {
+        // create directory
+        shell.mkdir('-p', targetDir);
+
+        // sync the content
+        fs.readFile(path.join(context.opts.plugin.dir, 'src', 'android', 'JPushPlugin.java'), {encoding: 'utf-8'}, function (err, data) {
+            if (err) {
+                throw err;
+            }
+
+            data = data.replace(/^import __PACKAGE_NAME__.R;/m, 'import ' + packageName + '.R;');
+            fs.writeFileSync(targetFile, data);
+        });
+    }
+};

--- a/src/android/JPushPlugin.java
+++ b/src/android/JPushPlugin.java
@@ -46,6 +46,7 @@ public class JPushPlugin extends CordovaPlugin {
 					"setLatestNotificationNum",
 					"setPushTime",
 					"clearAllNotification",
+                    "clearNotificationById",
 					"addLocalNotification",
 					"removeLocalNotification",
 					"clearLocalNotifications",

--- a/src/android/JPushPlugin.java
+++ b/src/android/JPushPlugin.java
@@ -19,7 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import java.util.Map.Entry;
 
-import your.package.name.R;
+import __PACKAGE_NAME__.R;
 
 import cn.jpush.android.api.BasicPushNotificationBuilder;
 import cn.jpush.android.api.CustomPushNotificationBuilder;

--- a/src/ios/PushConfig.plist
+++ b/src/ios/PushConfig.plist
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>APP_KEY</key>
-	<string>7d431e42dfa6a6d693ac2d04</string>
-	<key>CHANNEL</key>
-	<string>Subscription</string>
-</dict>
+    <dict>
+        <key>APP_KEY</key>
+        <string></string>
+        <key>CHANNEL</key>
+        <string>Subscription</string>
+    </dict>
 </plist>

--- a/www/JPushPlugin.js
+++ b/www/JPushPlugin.js
@@ -253,6 +253,13 @@ JPushPlugin.prototype.clearAllNotification = function(){
 	}
 }
 
+JPushPlugin.prototype.clearNotificationById = function(notificationId){
+    if(device.platform == "Android") {
+        data=[]
+        this.call_native("clearNotificationById",[notificationId],null);
+    }
+}
+
 JPushPlugin.prototype.setLatestNotificationNum = function(num){
    	if(device.platform == "Android") {
 		this.call_native("setLatestNotificationNum",[num],null);


### PR DESCRIPTION
在本地测试了一下，Android和iOS都可以零配置实现推送，安装方法：

cordova plugin add https://github.com/jpush/jpush-phonegap-plugin.git --variable API_KEY=xxxkey