### PR TITLE
将jcore库分离，防止多个极光插件库文件冲突

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
+    <dependency id="cordova-plugin-jcore" version="1.0.1"/>
 
     <js-module src="www/JPushPlugin.js" name="JPushPlugin">
         <clobbers target="JPush" />
@@ -38,7 +39,6 @@
 
         <header-file src="src/ios/lib/JPUSHService.h" />
         <source-file src="src/ios/lib/jpush-ios-3.0.0.a" framework="true" />
-        <source-file src="src/ios/lib/jcore-ios-1.0.0.a" framework="true" />
         <resource-file src="src/ios/PushConfig.plist" />
 
         <framework src="CFNetwork.framework" weak="true" />
@@ -177,12 +177,6 @@
         </config-file>
 
         <source-file src="src/android/libs/jpush-android_v3.0.0.jar" target-dir="libs" />
-        <source-file src="src/android/libs/jcore-android_v1.0.0.jar" target-dir="libs" />
-        <source-file src="src/android/libs/armeabi/libjcore100.so" target-dir="libs/armeabi" />
-        <source-file src="src/android/libs/armeabi-v7a/libjcore100.so" target-dir="libs/armeabi-v7a" />
-        <source-file src="src/android/libs/arm64-v8a/libjcore100.so" target-dir="libs/arm64-v8a" />
-        <source-file src="src/android/libs/x86/libjcore100.so" target-dir="libs/x86" />
-        <source-file src="src/android/libs/x86_64/libjcore100.so" target-dir="libs/x86_64" />
 
         <source-file src="src/android/MyReceiver.java" target-dir="src/cn/jpush/phonegap" />
         <source-file src="src/android/JPushPlugin.java" target-dir="src/cn/jpush/phonegap" />


### PR DESCRIPTION
统一使用[cordova-plugin-jcore](https://github.com/wilhantian/cordova-plugin-jcore)作为极光共通库依赖